### PR TITLE
docs: add complete installation steps and update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,17 +1,30 @@
+# Copy this file to .env and fill in your actual values:
+#   cp .env.example .env
+
+# Required: Telegram bot token (get from @BotFather)
 BOT_TOKEN=your-telegram-bot-token
 
-# Public log channel for transparent database change history (LiNo format)
+# Optional: Public log channel for transparent database change history (LiNo format)
 # This channel stores all database changes for public transparency and auditability
 # Leave empty to disable public logging
 PUBLIC_LOG_CHANNEL=@YourPublicLogChannel
 
-# Copy this file to .env and fill in your actual values
+# Optional: Enable detailed logging traces (default: false)
+PUBLIC_LOG_TRACING=false
 
-# Rsync configuration
-RSYNC_USER=your_username
-RSYNC_HOST=your.server.com
-RSYNC_PORT=22
-RSYNC_DEST=/path/to/remote/directory
+# Optional: Enable repost mode to forward user message and post metadata separately (default: false)
+ENABLE_REPOSTS=false
+
+# ---------------------------------------------------------------------------
+# The following variables are only needed if you use sync_to_server.sh
+# to deploy .env and db.json to a remote server via rsync over SSH.
+# They are NOT required to run the bot itself.
+# ---------------------------------------------------------------------------
+
+# RSYNC_USER=your_username
+# RSYNC_HOST=your.server.com
+# RSYNC_PORT=22
+# RSYNC_DEST=/path/to/remote/directory
 
 # Optional: path to SSH private key (uncomment if needed)
 # SSH_KEY_PATH=/path/to/your/private/key

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-15T19:19:00.121Z for PR creation at branch issue-39-7caa76f29d8c for issue https://github.com/correlation-center/corcen-telegram-bot/issues/39

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-15T19:19:00.121Z for PR creation at branch issue-39-7caa76f29d8c for issue https://github.com/correlation-center/corcen-telegram-bot/issues/39

--- a/README.md
+++ b/README.md
@@ -81,7 +81,39 @@ Changes use the link-cli single substitution format:
 
 ## Setup
 
-Create a `.env` file with your Telegram bot token:
+### 1. Install prerequisites
+
+Install `curl` and `unzip` (required to install Bun):
+
+```bash
+apt install curl unzip
+```
+
+Install [Bun](https://bun.sh):
+
+```bash
+curl -fsSL https://bun.sh/install | bash
+```
+
+After installation, reload your shell or follow the instructions printed by the installer to add Bun to your PATH.
+
+### 2. Clone the repository and install dependencies
+
+```bash
+git clone https://github.com/correlation-center/corcen-telegram-bot.git
+cd corcen-telegram-bot
+bun install
+```
+
+### 3. Configure environment
+
+Copy the example environment file and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` with your Telegram bot token (required) and optional settings:
 
 ```
 BOT_TOKEN=your-telegram-bot-token
@@ -90,13 +122,7 @@ PUBLIC_LOG_TRACING=true                    # Optional: enable detailed logging t
 ENABLE_REPOSTS=true                        # Optional: enable repost mode to forward user message and post metadata separately
 ```
 
-Install dependencies with Bun:
-
-```bash
-bun install
-```
-
-Start the bot with Bun:
+### 4. Start the bot
 
 ```bash
 bun run start


### PR DESCRIPTION
## Summary

Fixes #39

- Added step-by-step **Setup** section to `README.md` covering all prerequisites: installing `curl`, `unzip`, and `bun`, then cloning the repo, installing dependencies (`bun install`), and configuring the `.env` file via `cp .env.example .env`
- Updated `.env.example` to add the missing `PUBLIC_LOG_TRACING` and `ENABLE_REPOSTS` variables, and moved the `RSYNC_*` variables to a clearly labelled optional section (only needed for `sync_to_server.sh`, not for running the bot itself)

## Test plan

- [ ] Follow the updated README.md Setup steps on a fresh Ubuntu machine and verify the bot starts without errors
- [ ] Confirm `cp .env.example .env` produces a `.env` that only requires filling in `BOT_TOKEN` to get the bot running
- [ ] Confirm `RSYNC_*` variables are clearly marked as optional / deployment-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)